### PR TITLE
BUG: incorrect variable name base_mask_im

### DIFF
--- a/lib/StrokeCollateralVessels_Lib.py
+++ b/lib/StrokeCollateralVessels_Lib.py
@@ -409,7 +409,7 @@ def scv_register_ctp_images(fixed_image_file,
     mask_obj.SetImage(mask_im)
     mask_obj.Update()
     if debug and output_dir!=None:
-        itk.imwrite(base_mask_im,
+        itk.imwrite(mask_im,
             output_dir+"/mask.mha",
             compression=True)
 


### PR DESCRIPTION
If debugging is turned on, writing the mask.mha file used the incorrect variable name.

base_mask_im -> mask_im